### PR TITLE
add sign and verify to transit api

### DIFF
--- a/src/engines/transit_types-ti.ts
+++ b/src/engines/transit_types-ti.ts
@@ -6,6 +6,12 @@ import * as t from "ts-interface-checker";
 
 export const ITransitKeyType = t.union(t.lit("aes256-gcm96"), t.lit("chacha20-poly1305"), t.lit("d25519"), t.lit("ecdsa-p256"), t.lit("rsa-2048"), t.lit("rsa-4096"));
 
+export const ITransitSignHashAlgorithm = t.union(t.lit("sha1"), t.lit("sha2-224"), t.lit("sha2-256"), t.lit("sha2-384"), t.lit("sha2-512"), t.lit("sha3-224"), t.lit("sha3-256"), t.lit("sha3-384"), t.lit("sha3-512"));
+
+export const ITransitSignSignatureAlgorithm = t.union(t.lit("pss"), t.lit("pkcs1v15"));
+
+export const ITransitSignMarshalingAlgorithm = t.union(t.lit("asn1"), t.lit("jws"));
+
 export const ITransitBatchPlaintext = t.array(t.iface([], {
   "plaintext": "string",
   "context": t.opt("string"),
@@ -19,6 +25,29 @@ export const ITransitRawBatchPlaintext = t.array(t.iface([], {
 export const ITransitBatchCiphertext = t.array(t.iface([], {
   "ciphertext": "string",
   "context": t.opt("string"),
+}));
+
+export const ITransitSignBatchInput = t.array(t.iface([], {
+  "input": "string",
+  "context": t.opt("string"),
+}));
+
+export const ITransitVerifyBatchInputSignature = t.array(t.iface([], {
+  "input": "string",
+  "signature": "string",
+  "context": t.opt("string"),
+}));
+
+export const ITransitVerifyBatchInputHMAC = t.array(t.iface([], {
+  "input": "string",
+  "hmac": "string",
+  "context": t.opt("string"),
+}));
+
+export const ITransitSignBatchOutput = t.array(t.iface([], {
+  "signature": t.opt("string"),
+  "publickey": t.opt("string"),
+  "error": t.opt("string"),
 }));
 
 export const ITransitCreateOptions = t.iface([], {
@@ -136,11 +165,82 @@ export const ITransitDecryptRawResponseBatch = t.iface([], {
   }),
 });
 
+export const ITransitSignOptionsSingle = t.iface([], {
+  "key_version": t.opt("number"),
+  "hash_algorithm": t.opt("ITransitSignHashAlgorithm"),
+  "input": "string",
+  "context": t.opt("string"),
+  "prehashed": t.opt("boolean"),
+  "signature_algorithm": t.opt("ITransitSignSignatureAlgorithm"),
+  "marshaling_algorithm": t.opt("ITransitSignMarshalingAlgorithm"),
+});
+
+export const ITransitSignOptionsBatch = t.iface([], {
+  "key_version": t.opt("number"),
+  "hash_algorithm": t.opt("ITransitSignHashAlgorithm"),
+  "batch_input": "ITransitSignBatchInput",
+  "prehashed": t.opt("boolean"),
+  "signature_algorithm": t.opt("ITransitSignSignatureAlgorithm"),
+  "marshaling_algorithm": t.opt("ITransitSignMarshalingAlgorithm"),
+});
+
+export const ITransitSignResponseSingle = t.iface([], {
+  "data": t.iface([], {
+    "signature": t.union("string", "undefined"),
+  }),
+});
+
+export const ITransitSignResponseBatch = t.iface([], {
+  "data": t.iface([], {
+    "batch_results": "ITransitSignBatchOutput",
+  }),
+});
+
+export const ITransitVerifyOptionsSingle = t.iface([], {
+  "input": "string",
+  "signature": t.opt("string"),
+  "hmac": t.opt("string"),
+  "hash_algorithm": t.opt("ITransitSignHashAlgorithm"),
+  "context": t.opt("string"),
+  "prehashed": t.opt("boolean"),
+  "signature_algorithm": t.opt("ITransitSignSignatureAlgorithm"),
+  "marshaling_algorithm": t.opt("ITransitSignMarshalingAlgorithm"),
+});
+
+export const ITransitVerifyOptionsBatch = t.iface([], {
+  "batch_input": t.union("ITransitVerifyBatchInputSignature", "ITransitVerifyBatchInputHMAC"),
+  "hash_algorithm": t.opt("ITransitSignHashAlgorithm"),
+  "prehashed": t.opt("boolean"),
+  "signature_algorithm": t.opt("ITransitSignSignatureAlgorithm"),
+  "marshaling_algorithm": t.opt("ITransitSignMarshalingAlgorithm"),
+});
+
+export const ITransitVerifyResponseSingle = t.iface([], {
+  "data": t.iface([], {
+    "valid": "boolean",
+  }),
+});
+
+export const ITransitVerifyResponseBatch = t.iface([], {
+  "data": t.iface([], {
+    "batch_results": t.array(t.iface([], {
+      "valid": "boolean",
+    })),
+  }),
+});
+
 const exportedTypeSuite: t.ITypeSuite = {
   ITransitKeyType,
+  ITransitSignHashAlgorithm,
+  ITransitSignSignatureAlgorithm,
+  ITransitSignMarshalingAlgorithm,
   ITransitBatchPlaintext,
   ITransitRawBatchPlaintext,
   ITransitBatchCiphertext,
+  ITransitSignBatchInput,
+  ITransitVerifyBatchInputSignature,
+  ITransitVerifyBatchInputHMAC,
+  ITransitSignBatchOutput,
   ITransitCreateOptions,
   ITransitReadResponse,
   ITransitListResponse,
@@ -156,5 +256,13 @@ const exportedTypeSuite: t.ITypeSuite = {
   ITransitDecryptResponseSingle,
   ITransitDecryptResponseBatch,
   ITransitDecryptRawResponseBatch,
+  ITransitSignOptionsSingle,
+  ITransitSignOptionsBatch,
+  ITransitSignResponseSingle,
+  ITransitSignResponseBatch,
+  ITransitVerifyOptionsSingle,
+  ITransitVerifyOptionsBatch,
+  ITransitVerifyResponseSingle,
+  ITransitVerifyResponseBatch,
 };
 export default exportedTypeSuite;

--- a/src/engines/transit_types.ts
+++ b/src/engines/transit_types.ts
@@ -1,4 +1,16 @@
 export type ITransitKeyType = "aes256-gcm96" | "chacha20-poly1305" | "d25519" | "ecdsa-p256" | "rsa-2048" | "rsa-4096";
+export type ITransitSignHashAlgorithm =
+    | "sha1"
+    | "sha2-224"
+    | "sha2-256"
+    | "sha2-384"
+    | "sha2-512"
+    | "sha3-224"
+    | "sha3-256"
+    | "sha3-384"
+    | "sha3-512";
+export type ITransitSignSignatureAlgorithm = "pss" | "pkcs1v15";
+export type ITransitSignMarshalingAlgorithm = "asn1" | "jws";
 
 export type ITransitBatchPlaintext = Array<{
     plaintext: string;
@@ -11,6 +23,25 @@ export type ITransitRawBatchPlaintext = Array<{
 export type ITransitBatchCiphertext = Array<{
     ciphertext: string;
     context?: string;
+}>;
+export type ITransitSignBatchInput = Array<{
+    input: string;
+    context?: string;
+}>;
+export type ITransitVerifyBatchInputSignature = Array<{
+    input: string;
+    signature: string;
+    context?: string;
+}>;
+export type ITransitVerifyBatchInputHMAC = Array<{
+    input: string;
+    hmac: string;
+    context?: string;
+}>;
+export type ITransitSignBatchOutput = Array<{
+    signature?: string;
+    publickey?: string;
+    error?: string;
 }>;
 
 export interface ITransitCreateOptions {
@@ -125,5 +156,65 @@ export interface ITransitDecryptResponseBatch {
 export interface ITransitDecryptRawResponseBatch {
     data: {
         batch_results: ITransitRawBatchPlaintext;
+    };
+}
+
+export interface ITransitSignOptionsSingle {
+    key_version?: number;
+    hash_algorithm?: ITransitSignHashAlgorithm;
+    input: string;
+    context?: string;
+    prehashed?: boolean;
+    signature_algorithm?: ITransitSignSignatureAlgorithm;
+    marshaling_algorithm?: ITransitSignMarshalingAlgorithm;
+}
+export interface ITransitSignOptionsBatch {
+    key_version?: number;
+    hash_algorithm?: ITransitSignHashAlgorithm;
+    batch_input: ITransitSignBatchInput;
+    prehashed?: boolean;
+    signature_algorithm?: ITransitSignSignatureAlgorithm;
+    marshaling_algorithm?: ITransitSignMarshalingAlgorithm;
+}
+
+export interface ITransitSignResponseSingle {
+    data: {
+        signature: string | undefined;
+    };
+}
+export interface ITransitSignResponseBatch {
+    data: {
+        batch_results: ITransitSignBatchOutput;
+    };
+}
+
+export interface ITransitVerifyOptionsSingle {
+    input: string;
+    signature?: string;
+    hmac?: string;
+    hash_algorithm?: ITransitSignHashAlgorithm;
+    context?: string;
+    prehashed?: boolean;
+    signature_algorithm?: ITransitSignSignatureAlgorithm;
+    marshaling_algorithm?: ITransitSignMarshalingAlgorithm;
+}
+export interface ITransitVerifyOptionsBatch {
+    batch_input: ITransitVerifyBatchInputSignature | ITransitVerifyBatchInputHMAC;
+    hash_algorithm?: ITransitSignHashAlgorithm;
+    prehashed?: boolean;
+    signature_algorithm?: ITransitSignSignatureAlgorithm;
+    marshaling_algorithm?: ITransitSignMarshalingAlgorithm;
+}
+
+export interface ITransitVerifyResponseSingle {
+    data: {
+        valid: boolean;
+    };
+}
+export interface ITransitVerifyResponseBatch {
+    data: {
+        batch_results: Array<{
+            valid: boolean;
+        }>;
     };
 }

--- a/tests/util.spec.ts
+++ b/tests/util.spec.ts
@@ -18,6 +18,6 @@ describe("URL Resolve", () => {
 
     test("URL Resolve fails with invalid URL", () => {
         const resolveWrap = () => resolveURL("ht/example", "/test///", "////foo/baz/lul", "/bar///");
-        expect(resolveWrap).toThrowError(new TypeError("Invalid URL: ht/example/test/foo/baz/lul/bar"));
+        expect(resolveWrap).toThrowError(new RegExp("Invalid URL.*"));
     });
 });


### PR DESCRIPTION
Added support for the sign and verify capabilities of the transit engine. Added tests for a few basic functionalities.