### PR TITLE
Use existing vault image instead of removed latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,9 @@ on:
     types: [created]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "20.x"
           registry-url: "https://npm.pkg.github.com"
           # Defaults to the user or organization that owns the workflow file
           scope: "@mittwald"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: node:12
     services:
       vault:
@@ -11,7 +11,7 @@ jobs:
         env:
           VAULT_DEV_ROOT_TOKEN_ID: "test"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-22.04
-    container: node:12
+    container: node:20
     services:
       vault:
         image: vault:1.13.3
@@ -15,7 +15,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "20.x"
           registry-url: "https://npm.pkg.github.com"
           # Defaults to the user or organization that owns the workflow file
           scope: "@mittwald"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     container: node:12
     services:
       vault:
-        image: vault
+        image: vault:1.13.3
         env:
           VAULT_DEV_ROOT_TOKEN_ID: "test"
     steps:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   vault:
-    image: vault
+    image: vault:1.13.3
     ports:
       - "8200:8200"
     command: [

--- a/tests/engines/transit.spec.ts
+++ b/tests/engines/transit.spec.ts
@@ -93,6 +93,12 @@ describe("Transit Vault Client", () => {
                     plaintext: "",
                 },
             ];
+            const expectedOutput = input.map((entry) => {
+                return {
+                    ...entry,
+                    reference: "",
+                };
+            });
 
             const result = await client
                 .encrypt("test", {
@@ -108,7 +114,7 @@ describe("Transit Vault Client", () => {
                 })
                 .then((res) => res.data.batch_results);
 
-            expect(res).toEqual(input);
+            expect(res).toEqual(expectedOutput);
         });
 
         test("successfully encrypt and decrypt simple plaintext", async () => {


### PR DESCRIPTION
Observed here: https://github.com/mittwald/vaulTS/actions/runs/16515068510/job/46704252291?pr=42

'latest' which was used as default, is not available anymore: https://hub.docker.com/_/vault